### PR TITLE
support comma separated string as if it were a string slice

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -410,7 +410,9 @@ value is not string, return the default
 ```go
 func (o *Onion) GetStringSlice(key string) []string
 ```
-GetStringSlice try to get a slice from the config
+GetStringSlice will try to get a string slice for the given key. If the value
+is just a string, it will be split (via commas) to create a string slice. If
+the value is a slice with non-string elements, the return will be empty.
 
 #### func (*Onion) GetStruct
 

--- a/onion.go
+++ b/onion.go
@@ -396,7 +396,11 @@ func (o *Onion) GetStringSlice(key string) []string {
 	var ok bool
 	v, ok := o.getSlice(key)
 	if !ok {
-		return nil
+		str := o.GetString(key)
+		if len(str) <= 0 {
+			return nil
+		}
+		v = strings.Split(str, ",")
 	}
 
 	switch nv := v.(type) {

--- a/onion_test.go
+++ b/onion_test.go
@@ -103,6 +103,7 @@ func TestOnion(t *testing.T) {
 		lm.data["slice3"] = []interface{}{"a", "b", true}
 		lm.data["slice4"] = []int{1, 2, 3}
 		lm.data["ignored"] = "ignore me"
+		lm.data["strAsSlice"] = "one,two,three"
 
 		lm.data["dur"] = time.Minute
 		lm.data["durstring"] = "1h2m3s"
@@ -245,9 +246,11 @@ func TestOnion(t *testing.T) {
 			So(reflect.DeepEqual(o.GetStringSlice("slice1"), []string{"a", "b", "c"}), ShouldBeTrue)
 			So(reflect.DeepEqual(o.GetStringSlice("slice2"), []string{"a", "b", "c"}), ShouldBeTrue)
 			So(o.GetStringSlice("slice3"), ShouldBeNil)
+			So(o.GetStringSlice("slice4"), ShouldBeNil)
 			So(o.GetStringSlice("notslice3"), ShouldBeNil)
 			So(o.GetStringSlice("yes.str1"), ShouldBeNil)
-			So(o.GetStringSlice("slice4"), ShouldBeNil)
+			So(reflect.DeepEqual(o.GetStringSlice("yes.str2"), []string{"hi"}), ShouldBeTrue)
+			So(reflect.DeepEqual(o.GetStringSlice("strAsSlice"), []string{"one", "two", "three"}), ShouldBeTrue)
 		})
 	})
 


### PR DESCRIPTION
I wanted to use a list of strings for a config param, but I wanted to be able to get that list from an environment variable.

My solution is to modify GetStringSlice so that if it doesn't find a slice, it will then see if it has a string instead. If so, it splits that string on any commas, creating a []string.
